### PR TITLE
allow apns headers to be passed as parameters from the json body request

### DIFF
--- a/request.go
+++ b/request.go
@@ -40,6 +40,7 @@ type Alert struct {
 
 // PostedData is posted data to this provider server /push/apns.
 type PostedData struct {
+	Header  Header  `json:"header,omitempty"`
 	Token   string  `json:"token"`
 	Payload Payload `json:"payload"`
 }

--- a/server.go
+++ b/server.go
@@ -210,6 +210,7 @@ func (prov *Provider) pushHandler() http.HandlerFunc {
 			}
 
 			req := Request{
+				Header:  p.Header,
 				Token:   p.Token,
 				Payload: p.Payload,
 				Tries:   0,


### PR DESCRIPTION
ref: #3

This PR fixes a problem where the Request.Header struct is left uninitialized even when a valid header key is included in the json post body.

Being able to customize the apns-topic header is required for certificates that include multiple topics