### PR TITLE
Refactor response

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,21 +49,21 @@ payload | APNS notification payload
 Post JSON example:
 ```json
 [
-    {
-        "payload": {
-            "aps": {
-                  "alert": "test notification",
-                  "sound": "default"
-            },
-            "option1": "foo",
-            "option2": "bar"
-        },
-        "token": "apns device token",
-        "header": {
-            "apns-id": "your apns id"
-            "apns-token": "your app bundle id"
-        }
+  {
+    "payload": {
+      "aps": {
+        "alert": "test notification",
+        "sound": "default"
+      },
+      "option1": "foo",
+      "option2": "bar"
+    },
+    "token": "apns device token",
+    "header": {
+      "apns-id": "your apns id",
+      "apns-token": "your app bundle id"
     }
+  }
 ]
 ```
 
@@ -156,7 +156,8 @@ for example JSON structure: (>= v0.2.x)
 {
   "provider": "fcm",
   "status": 200,
-  "registration_id": "8kMSTcfqrca:APA91bEfS-uC1WV374Mg83Lkn43",
+  "registration_id": "8kMSTcfqrca:APA91bEfS-uC1WV374Mg83Lkn43..",
+  // or "to": "8kMSTcfqrca:APA91bEfS-uC1WV374Mg83Lkn43..",
   "error": "InvalidRegistration"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ type CustomYourErrorHandler struct {
     hookCmd string
 }
 
-func (ch CustomYourErrorHandler) OnResponse( req *Request, res *Response, err error ){
+func (ch CustomYourErrorHandler) OnResponse(result Result){
     // ...
 }
 

--- a/README.md
+++ b/README.md
@@ -139,33 +139,55 @@ error_hook       |optional| Error hook command. This command runs when Gunfish c
 
 Error hook command can get an each error response with JSON format by STDIN.
 
-for example JSON structure:
+for example JSON structure: (>= v0.2.x)
+```json5
+// APNs
+{
+  "provider": "apns",
+  "apns-id": "123e4567-e89b-12d3-a456-42665544000",
+  "status": 400,
+  "token": "9fe817acbcef8173fb134d8a80123cba243c8376af83db8caf310daab1f23003",
+  "reason": "MissingTopic"
+}
+```
+
+```json5
+// FCM
+{
+  "provider": "fcm",
+  "status": 200,
+  "registration_id": "8kMSTcfqrca:APA91bEfS-uC1WV374Mg83Lkn43",
+  "error": "InvalidRegistration"
+}
+```
+
+(~ v0.1.x)
 ```json
 {
   "response": {
- "apns-id": "",
- "status": 400
+    "apns-id": "",
+    "status": 400
   },
   "response_time": 0.633673848,
   "request": {
- "header": {},
- "token": "9fe817acbcef8173fb134d8a80123cba243c8376af83db8caf310daab1f23003",
- "payload": {
-   "aps": {
-     "alert": "error alert test",
-     "badge": 1,
-     "sound": "default"
-   },
-   "Optional": {
-     "option1": "hoge",
-     "option2": "hoge"
-   }
- },
- "tries": 0
+    "header": {},
+    "token": "9fe817acbcef8173fb134d8a80123cba243c8376af83db8caf310daab1f23003",
+    "payload": {
+      "aps": {
+        "alert": "error alert test",
+        "badge": 1,
+        "sound": "default"
+      },
+      "Optional": {
+        "option1": "hoge",
+        "option2": "hoge"
+      }
+    },
+    "tries": 0
   },
   "error_msg": {
- "reason": "MissingTopic",
- "timestamp": 0
+    "reason": "MissingTopic",
+    "timestamp": 0
   }
 }
 ```

--- a/apns/response.go
+++ b/apns/response.go
@@ -1,17 +1,65 @@
 package apns
 
+import (
+	"encoding/json"
+	"errors"
+)
+
+const Provider = "apns"
+
 // Response from apns
-type Response struct {
+type Result struct {
 	APNsID     string `json:"apns-id"`
 	StatusCode int    `json:"status"`
+	Token      string `json:"token"`
+	Reason     string `json:"reason"`
 }
 
-// ErrorResponse from apns
+func (r Result) Err() error {
+	if r.StatusCode == 200 && r.Reason == "" {
+		return nil
+	}
+	return errors.New(r.Reason)
+}
+
+func (r Result) RecipientIdentifier() string {
+	return r.Token
+}
+
+func (r Result) ExtraKeys() []string {
+	return []string{"apns-id", "reason"}
+}
+
+func (r Result) ExtraValue(key string) string {
+	switch key {
+	case "apns-id":
+		return r.APNsID
+	case "reason":
+		return r.Reason
+	}
+	return ""
+}
+
+func (r Result) Status() int {
+	return r.StatusCode
+}
+
+func (r Result) Provider() string {
+	return Provider
+}
+
+func (r *Result) MarshalJSON() ([]byte, error) {
+	type Alias Result
+	return json.Marshal(&struct {
+		Provider string `json:"provider"`
+		*Alias
+	}{
+		Provider: Provider,
+		Alias:    (*Alias)(r),
+	})
+}
+
 type ErrorResponse struct {
 	Reason    string `json:"reason"`
 	Timestamp int64  `json:"timestamp"`
-}
-
-func (e *ErrorResponse) Error() string {
-	return e.Reason
 }

--- a/client.go
+++ b/client.go
@@ -2,5 +2,5 @@ package gunfish
 
 // Client interface for fcm and apns client
 type Client interface {
-	Send(Notification) (*Response, error)
+	Send(Notification) ([]Result, error)
 }

--- a/fcm/client.go
+++ b/fcm/client.go
@@ -22,7 +22,7 @@ type Client struct {
 	Client   *http.Client
 }
 
-// Send sends notifications to fcm (TODO: send retry)
+// Send sends notifications to fcm
 func (c *Client) Send(p Payload) ([]Result, error) {
 	req, err := c.NewRequest(p)
 	if err != nil {
@@ -44,13 +44,12 @@ func (c *Client) Send(p Payload) ([]Result, error) {
 	if res.StatusCode != http.StatusOK {
 		return nil, NewError(res.StatusCode, "status is not OK")
 	}
-
 	if len(p.RegistrationIDs) == 0 && len(body.Results) == 1 {
 		r := body.Results[0]
 		r.To = p.To
 		r.StatusCode = res.StatusCode
 		return []Result{r}, nil
-	} else if len(p.RegistrationIDs) == len(body.Results) {
+	} else if len(p.RegistrationIDs) > 0 && len(p.RegistrationIDs) == len(body.Results) {
 		ret := make([]Result, 0, len(body.Results))
 		for i, r := range body.Results {
 			r.RegistrationID = p.RegistrationIDs[i]

--- a/fcm/client.go
+++ b/fcm/client.go
@@ -23,59 +23,58 @@ type Client struct {
 }
 
 // Send sends notifications to fcm (TODO: send retry)
-func (gc *Client) Send(p Payload) (*Response, error) {
-	req, err := gc.NewRequest(p)
+func (c *Client) Send(p Payload) ([]Result, error) {
+	req, err := c.NewRequest(p)
 	if err != nil {
 		return nil, err
 	}
 
-	res, err := gc.Client.Do(req)
+	res, err := c.Client.Do(req)
 	if err != nil {
 		return nil, err
 	}
 	defer res.Body.Close()
 
-	resp := &Response{}
+	var body ResponseBody
 	dec := json.NewDecoder(res.Body)
-	if err = dec.Decode(&resp.Body); err != nil {
-		return nil, err
-	}
-	resp.Header.StatusCode = res.StatusCode
-
-	if res.StatusCode == http.StatusOK {
-		return resp, err
+	if err = dec.Decode(&body); err != nil {
+		return nil, NewError(res.StatusCode, err.Error())
 	}
 
-	var errCodes []string
-	if resp.Body.Error != "" {
-		errCodes = append(errCodes, resp.Body.Error)
-	} else {
-		for _, msg := range resp.Body.Results {
-			if msg.Error != "" {
-				errCodes = append(errCodes, msg.Error)
-			}
+	if res.StatusCode != http.StatusOK {
+		return nil, NewError(res.StatusCode, "status is not OK")
+	}
+
+	if len(p.RegistrationIDs) == 0 && len(body.Results) == 1 {
+		r := body.Results[0]
+		r.To = p.To
+		r.StatusCode = res.StatusCode
+		return []Result{r}, nil
+	} else if len(p.RegistrationIDs) == len(body.Results) {
+		ret := make([]Result, 0, len(body.Results))
+		for i, r := range body.Results {
+			r.RegistrationID = p.RegistrationIDs[i]
+			r.StatusCode = res.StatusCode
+			ret = append(ret, r)
 		}
+		return ret, nil
 	}
-	eres := ErrorResponse{
-		StatusCode: resp.Header.StatusCode,
-		ErrCodes:   errCodes,
-	}
-	return nil, eres
+
+	return nil, NewError(res.StatusCode, "unexpected response")
 }
 
 // NewRequest creates request for fcm
-func (gc *Client) NewRequest(p Payload) (*http.Request, error) {
-
+func (c *Client) NewRequest(p Payload) (*http.Request, error) {
 	data, err := json.Marshal(p)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := http.NewRequest("POST", gc.endpoint.String(), bytes.NewReader(data))
+	req, err := http.NewRequest("POST", c.endpoint.String(), bytes.NewReader(data))
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Authorization", fmt.Sprintf("key=%s", gc.apiKey))
+	req.Header.Set("Authorization", fmt.Sprintf("key=%s", c.apiKey))
 	req.Header.Set("Content-Type", "application/json")
 
 	return req, nil
@@ -87,17 +86,17 @@ func NewClient(apikey string, endpoint *url.URL, timeout time.Duration) *Client 
 		Timeout: timeout,
 	}
 
-	gc := &Client{
+	c := &Client{
 		apiKey: apikey,
 		Client: client,
 	}
 
 	if endpoint != nil {
-		gc.endpoint = endpoint
+		c.endpoint = endpoint
 
 	} else {
-		gc.endpoint, _ = url.Parse(DefaultFCMEndpoint)
+		c.endpoint, _ = url.Parse(DefaultFCMEndpoint)
 	}
 
-	return gc
+	return c
 }

--- a/fcm/error.go
+++ b/fcm/error.go
@@ -1,5 +1,7 @@
 package fcm
 
+import "fmt"
+
 type FCMErrorResponseCode int
 
 // Error const variables
@@ -30,3 +32,19 @@ const (
 	// UnknownError
 	UnknownError
 )
+
+type Error struct {
+	StatusCode int
+	Reason     string
+}
+
+func (e Error) Error() string {
+	return fmt.Sprintf("status:%d reason:%s", e.StatusCode, e.Reason)
+}
+
+func NewError(s int, r string) Error {
+	return Error{
+		StatusCode: s,
+		Reason:     r,
+	}
+}

--- a/fcm/response.go
+++ b/fcm/response.go
@@ -1,29 +1,11 @@
 package fcm
 
 import (
-	"fmt"
+	"encoding/json"
+	"errors"
 )
 
-// ErrorResponse is fcm error response
-type ErrorResponse struct {
-	ErrCodes   []string
-	StatusCode int
-}
-
-func (er ErrorResponse) Error() string {
-	return fmt.Sprintf("%v:[http_status:%d]", er.ErrCodes, er.StatusCode)
-}
-
-// Response is the fcm connection server response
-type Response struct {
-	Header ResponseHeader `json:"header"`
-	Body   ResponseBody   `json:"body"`
-}
-
-// ResponseHeader fcm response header
-type ResponseHeader struct {
-	StatusCode int `json:"status_code"`
-}
+const Provider = "fcm"
 
 // ResponseBody fcm response body
 type ResponseBody struct {
@@ -33,12 +15,60 @@ type ResponseBody struct {
 	CanonicalIDs int      `json:"canonical_ids"`
 	Results      []Result `json:"results,omitempty"`
 	MessageID    int      `json:"message_id,omitempty"`
-	Error        string   `json:"error,omitempty"`
 }
 
 // Result is the status of a processed FCMResponse
 type Result struct {
+	StatusCode     int    `json:"status",omitempty`
 	MessageID      string `json:"message_id,omitempty"`
+	To             string `json:"to,omitempty"`
 	RegistrationID string `json:"registration_id,omitempty"`
 	Error          string `json:"error,omitempty"`
+}
+
+func (r Result) Err() error {
+	if r.Error != "" {
+		return errors.New(r.Error)
+	}
+	return nil
+}
+
+func (r Result) Status() int {
+	return r.StatusCode
+}
+
+func (r Result) RecipientIdentifier() string {
+	if r.To != "" {
+		return r.To
+	}
+	return r.RegistrationID
+}
+
+func (r Result) ExtraKeys() []string {
+	return []string{"message_id", "error"}
+}
+
+func (r Result) Provider() string {
+	return Provider
+}
+
+func (r Result) ExtraValue(key string) string {
+	switch key {
+	case "message_id":
+		return r.MessageID
+	case "error":
+		return r.Error
+	}
+	return ""
+}
+
+func (r *Result) MarshalJSON() ([]byte, error) {
+	type Alias Result
+	return json.Marshal(&struct {
+		Provider string `json:"provider"`
+		*Alias
+	}{
+		Provider: Provider,
+		Alias:    (*Alias)(r),
+	})
 }

--- a/fcm/response_test.go
+++ b/fcm/response_test.go
@@ -7,71 +7,63 @@ import (
 )
 
 func TestUnmarshalResponse(t *testing.T) {
-	var r Response
-	if err := json.Unmarshal([]byte(buildResponseJSON()), &r); err != nil {
+	var r ResponseBody
+	if err := json.Unmarshal([]byte(buildResponseBodyJSON()), &r); err != nil {
 		t.Error(err)
 	}
 
-	if !reflect.DeepEqual(r, buildResponse()) {
-		t.Errorf("mismatch decoded payload:\ngot=%v\nexpected=%v", r, buildResponse())
+	if !reflect.DeepEqual(r, buildResponseBody()) {
+		t.Errorf("mismatch decoded payload:\ngot=%v\nexpected=%v", r, buildResponseBody())
 	}
 }
 
 func TestMarshalResponse(t *testing.T) {
-	p := buildResponse()
+	p := buildResponseBody()
 	output, err := json.Marshal(p)
 	if err != nil {
 		t.Error(err)
 	}
 
-	expected := `{"header":{"status_code":200},"body":{"multicast_id":5302270091026410054,"success":3,"failure":0,"canonical_ids":0,"results":[{"message_id":"0:1487073977923500%caa8591dcaa8591d"},{"message_id":"0:1487073977923148%caa8591dcaa8591d"},{"message_id":"0:1487073977924484%caa8591dcaa8591d"}]}}`
+	expected := `{"multicast_id":5302270091026410054,"success":3,"failure":0,"canonical_ids":0,"results":[{"provider":"fcm","status":200,"message_id":"0:1487073977923500%caa8591dcaa8591d"},{"provider":"fcm","status":200,"message_id":"0:1487073977923148%caa8591dcaa8591d"},{"provider":"fcm","status":200,"message_id":"0:1487073977924484%caa8591dcaa8591d"}]}`
 
 	if string(output) != expected {
 		t.Errorf("mismatch decoded response:\ngot=%s\nexpected=%s", output, expected)
 	}
 }
 
-func buildResponse() Response {
-	return Response{
-		ResponseHeader{
-			StatusCode: 200,
-		},
-		ResponseBody{
-			MulticastID:  5302270091026410054,
-			Success:      3,
-			Failure:      0,
-			CanonicalIDs: 0,
-			Results: []Result{
-				Result{
-					MessageID: "0:1487073977923500%caa8591dcaa8591d",
-				},
-				Result{
-					MessageID: "0:1487073977923148%caa8591dcaa8591d",
-				},
-				Result{
-					MessageID: "0:1487073977924484%caa8591dcaa8591d",
-				},
+func buildResponseBody() ResponseBody {
+	return ResponseBody{
+		MulticastID:  5302270091026410054,
+		Success:      3,
+		Failure:      0,
+		CanonicalIDs: 0,
+		Results: []Result{
+			Result{
+				StatusCode: 200,
+				MessageID:  "0:1487073977923500%caa8591dcaa8591d",
+			},
+			Result{
+				StatusCode: 200,
+				MessageID:  "0:1487073977923148%caa8591dcaa8591d",
+			},
+			Result{
+				StatusCode: 200,
+				MessageID:  "0:1487073977924484%caa8591dcaa8591d",
 			},
 		},
 	}
 }
 
-func buildResponseJSON() string {
+func buildResponseBodyJSON() string {
 	return `{
-        "header": {
-            "status_code": 200
-        },
-        "body":
-        {
             "multicast_id":  5302270091026410054,
             "success":       3,
             "failure":       0,
             "canonical_ids": 0,
             "results": [
-                { "message_id": "0:1487073977923500%caa8591dcaa8591d" },
-                { "message_id": "0:1487073977923148%caa8591dcaa8591d" },
-                { "message_id": "0:1487073977924484%caa8591dcaa8591d" }
+                { "status":200, "message_id": "0:1487073977923500%caa8591dcaa8591d" },
+                { "status":200, "message_id": "0:1487073977923148%caa8591dcaa8591d" },
+                { "status":200, "message_id": "0:1487073977924484%caa8591dcaa8591d" }
             ]
-        }
-    }`
+        }`
 }

--- a/response.go
+++ b/response.go
@@ -1,3 +1,10 @@
 package gunfish
 
-type Response interface{}
+type Result interface {
+	Err() error
+	Status() int
+	Provider() string
+	RecipientIdentifier() string
+	ExtraKeys() []string
+	ExtraValue(string) string
+}

--- a/server.go
+++ b/server.go
@@ -31,7 +31,7 @@ type Provider struct {
 // ResponseHandler provides you to implement handling on success or on error response from apns.
 // Therefore, you can specifies hook command which is set at toml file.
 type ResponseHandler interface {
-	OnResponse(Request, Response, error)
+	OnResponse(Result)
 	HookCmd() string
 }
 
@@ -40,8 +40,8 @@ type DefaultResponseHandler struct {
 	hook string
 }
 
-// OnResponse is performed when to receive response from APNS.
-func (rh DefaultResponseHandler) OnResponse(req Request, res Response, err error) {
+// OnResponse is performed when to receive result from APNs or FCM.
+func (rh DefaultResponseHandler) OnResponse(result Result) {
 }
 
 // HookCmd returns hook command to execute after getting response from APNS

--- a/supervisor.go
+++ b/supervisor.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"sync"
@@ -38,13 +39,13 @@ type Worker struct {
 	wgrp           *sync.WaitGroup
 	sn             int
 	id             int
-	errorHandler   func(Request, Response, error)
-	successHandler func(Request, Response)
+	errorHandler   func(Request, *http.Response, error)
+	successHandler func(Request, *http.Response)
 }
 
 // SenderResponse is responses to worker from sender.
 type SenderResponse struct {
-	Res      Response `json:"response"`
+	Results  []Result `json:"response"`
 	RespTime float64  `json:"response_time"`
 	Req      Request  `json:"request"`
 	Err      error    `json:"error_msg"`
@@ -315,19 +316,22 @@ func (w *Worker) receiveResponse(resp SenderResponse, retryq chan<- Request, cmd
 
 func handleAPNsResponse(resp SenderResponse, retryq chan<- Request, cmdq chan Command, logf logrus.Fields) {
 	req := resp.Req
-	res := resp.Res.(*apns.Response)
+
 	// Response handling
 	if resp.Err != nil {
 		atomic.AddInt64(&(srvStats.ErrCount), 1)
-		if res != nil {
-			logf["status"] = fmt.Sprint(res.StatusCode)
-			logf["apns_id"] = res.APNsID
-
+		if len(resp.Results) > 0 {
+			result := resp.Results[0]
+			for _, key := range result.ExtraKeys() {
+				logf[key] = result.ExtraValue(key)
+			}
+			logf["status"] = result.Status()
 			LogWithFields(logf).Errorf("%s", resp.Err)
+			// Error handling
+			onResponse(result, errorResponseHandler.HookCmd(), cmdq)
 		} else {
-			// if 'res' is nil,  HTTP connection error with APNS.
+			// if 'result' is nil, HTTP connection error with APNS.
 			LogWithFields(logf).Warnf("response is nil. reason: %s", resp.Err.Error())
-
 			if req.Tries < SendRetryCount {
 				req.Tries++
 				atomic.AddInt64(&(srvStats.RetryCount), 1)
@@ -346,41 +350,35 @@ func handleAPNsResponse(resp SenderResponse, retryq chan<- Request, cmdq chan Co
 					Warnf("Retry count is over than %d. Could not deliver notification.", SendRetryCount)
 			}
 		}
-		// Error handling
-		onResponse(resp, errorResponseHandler.HookCmd(), cmdq)
 	} else {
 		atomic.AddInt64(&(srvStats.SentCount), 1)
-		logf["status"] = fmt.Sprint(res.StatusCode)
-		logf["apns_id"] = res.APNsID
-
+		if len(resp.Results) > 0 {
+			result := resp.Results[0]
+			for _, key := range result.ExtraKeys() {
+				logf[key] = result.ExtraValue(key)
+			}
+			onResponse(result, "", cmdq)
+		}
 		LogWithFields(logf).Info("Succeeded to send a notification")
-
-		// Success handling
-		onResponse(resp, "", cmdq) // success response handling does not execute hook command
 	}
 }
 
 func handleFCMResponse(resp SenderResponse, retryq chan<- Request, cmdq chan Command, logf logrus.Fields) {
-	res := resp.Res.(*fcm.Response)
-	if res == nil {
-		LogWithFields(logf).Warnf("response is nil. reason: %s", resp.Err.Error())
-		return
-	}
-
-	logf["results"] = res.Body.Results
-	for _, result := range res.Body.Results {
+	for _, result := range resp.Results {
 		// success when Error is nothing
-		if result.Error == "" {
+		err := result.Err()
+		if err == nil {
+			atomic.AddInt64(&(srvStats.SentCount), 1)
+			LogWithFields(logf).Info("Succeeded to send a notification")
 			continue
 		}
 		// handle error response each registration_id
 		atomic.AddInt64(&(srvStats.ErrCount), 1)
-		switch result.Error {
-		case fcm.InvalidRegistration.String():
+		if err.Error() == fcm.InvalidRegistration.String() {
 			// TODO: should delete registration_id from server data store
-			onResponse(resp, errorResponseHandler.HookCmd(), cmdq)
-		default:
-			LogWithFields(logf).Errorf("Unknown error message")
+			onResponse(result, errorResponseHandler.HookCmd(), cmdq)
+		} else {
+			LogWithFields(logf).Errorf("Unknown error message: %s", err)
 		}
 	}
 }
@@ -402,7 +400,7 @@ func (w *Worker) receiveRequests(reqs *[]Request) {
 	}
 }
 
-func spawnSender(wq <-chan Request, respq chan<- SenderResponse, wgrp *sync.WaitGroup, ac *apns.Client, gc *fcm.Client) {
+func spawnSender(wq <-chan Request, respq chan<- SenderResponse, wgrp *sync.WaitGroup, ac *apns.Client, fc *fcm.Client) {
 	defer wgrp.Done()
 	atomic.AddInt64(&(srvStats.Senders), 1)
 	for req := range wq {
@@ -411,10 +409,14 @@ func spawnSender(wq <-chan Request, respq chan<- SenderResponse, wgrp *sync.Wait
 		case apns.Notification:
 			no := req.Notification.(apns.Notification)
 			start := time.Now()
-			res, err := ac.Send(no)
+			results, err := ac.Send(no)
 			respTime := time.Now().Sub(start).Seconds()
+			rs := make([]Result, 0, len(results))
+			for _, v := range results {
+				rs = append(rs, v)
+			}
 			sres = SenderResponse{
-				Res:      res,
+				Results:  rs,
 				RespTime: respTime,
 				Req:      req, // Must copy
 				Err:      err,
@@ -423,10 +425,14 @@ func spawnSender(wq <-chan Request, respq chan<- SenderResponse, wgrp *sync.Wait
 		case fcm.Payload:
 			p := req.Notification.(fcm.Payload)
 			start := time.Now()
-			res, err := gc.Send(p)
+			results, err := fc.Send(p)
 			respTime := time.Now().Sub(start).Seconds()
+			rs := make([]Result, 0, len(results))
+			for _, v := range results {
+				rs = append(rs, v)
+			}
 			sres = SenderResponse{
-				Res:      res,
+				Results:  rs,
 				RespTime: respTime,
 				Req:      req,
 				Err:      err,
@@ -457,39 +463,30 @@ func (s Supervisor) workersAllQueueLength() int {
 	return sum
 }
 
-func onResponse(resp SenderResponse, cmd string, cmdq chan<- Command) {
-	res := (resp.Res).(*apns.Response)
-	req := resp.Req
-	noti := req.Notification.(apns.Notification)
-
+func onResponse(result Result, cmd string, cmdq chan<- Command) {
 	logf := logrus.Fields{
-		"type":    "on_response",
-		"token":   noti.Token,
-		"payload": noti.Payload,
+		"provider": result.Provider(),
+		"type":     "on_response",
+		"token":    result.RecipientIdentifier(),
 	}
-
+	for _, key := range result.ExtraKeys() {
+		logf[key] = result.ExtraValue(key)
+	}
 	// on error handler
-	if resp.Err != nil {
-		errorResponseHandler.OnResponse(req, res, resp.Err)
+	if err := result.Err(); err != nil {
+		errorResponseHandler.OnResponse(result)
 	} else {
-		successResponseHandler.OnResponse(req, res, nil)
+		successResponseHandler.OnResponse(result)
 	}
 
-	// if resp.Res is nil (that is http layer error), not execute command.
-	// command string is empty when to succeed to send notification.
-	if cmd == "" || resp.Res == nil {
+	if cmd == "" {
 		return
 	}
 
-	jresp, err := json.Marshal(resp)
-	if err != nil {
-		LogWithFields(logf).Errorf(err.Error())
-		return
-	}
-
+	b, _ := json.Marshal(&result)
 	command := Command{
 		command: cmd,
-		input:   jresp,
+		input:   b,
 	}
 	select {
 	case cmdq <- command:


### PR DESCRIPTION
`type Response` is `interface{}`.
Refactored to do not use `interface{}`
- Add type Result
  - a result of notification for each tokens.
- Change interface of Client.Send()
  - returns []Result