### PR TITLE
Config simply

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,14 +81,13 @@ stats type | description
 Pid | PID
 DebugPort | pprof port number
 Uptime | uptime of APNS provider server
-Workers | number of workers             
-Senders | number of senders 
+Workers | number of workers
 StartAt | The time of starting APNS provider server
 QueueSize | queue size of requests for Gunfish
 RetryQueueSize | queue size for resending notification
 WorkersQueueSize | summary of worker's queue size
-CommandQueueSize | error hook command queue size 
-RetryCount | summary of retry count 
+CommandQueueSize | error hook command queue size
+RetryCount | summary of retry count
 RequestCount | request count to gunfish
 ErrCount | count of recieving error response from APNs
 SentCount | count of sending notification to APNs
@@ -111,18 +110,19 @@ worker_num = 8
 queue_size = 2000
 max_request_size = 1000
 max_connections = 2000
+error_hook = "echo -e 'Hello Gunfish at error hook!'"
 
 [apns]
 skip_insecure = true
 key_file = "/path/to/server.key"
 cert_file = "/path/to/server.crt"
-sender_num = 50
-request_per_sec = 2000
-error_hook = "echo -e 'Hello Gunfish at error hook!'"
+
+[fcm]
+api_key = "API key for FCM"
 ```
 
 param            | status | description
----------------- | ------ | -------------------------------------------------------------------------------------- 
+---------------- | ------ | --------------------------------------------------------------------------------------
 port             |optional| Listen port number.
 worker_num       |optional| Number of Gunfish owns http clients.
 queue_size       |optional| Limit number of posted JSON from the developer application.
@@ -131,8 +131,6 @@ max_connections  |optional| Max connections
 skip_insecure    |optional| Controls whether a client verifies the server's certificate chain and host name.
 key_file         |required| The key file path.
 cert_file        |required| The cert file path.
-sender_num       |optional| Number of concurrency sending notification per http client.
-request_per_sec  |optional| Flow rate as notifications per sec no your application. (default: 2000).
 error_hook       |optional| Error hook command. This command runs when Gunfish catches an error response.
 
 ## Error Hook

--- a/apns/client.go
+++ b/apns/client.go
@@ -21,7 +21,7 @@ const (
 // Client is apns client
 type Client struct {
 	Host   string
-	Client *http.Client
+	client *http.Client
 }
 
 // Send sends notifications to apns
@@ -31,7 +31,7 @@ func (ac *Client) Send(n Notification) ([]Result, error) {
 		return nil, err
 	}
 
-	res, err := ac.Client.Do(req)
+	res, err := ac.client.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -125,5 +125,16 @@ func NewConnection(certFile, keyFile string, secuskip bool) (*http.Client, error
 	return &http.Client{
 		Timeout:   HTTP2ClientTimeout,
 		Transport: tr,
+	}, nil
+}
+
+func NewClient(host, cert, key string, skipInsecure bool) (*Client, error) {
+	c, err := NewConnection(cert, key, skipInsecure)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{
+		Host:   host,
+		client: c,
 	}, nil
 }

--- a/conf/gunfish.toml.example
+++ b/conf/gunfish.toml.example
@@ -4,11 +4,12 @@ worker_num = 8
 queue_size = 2000
 max_request_size = 1000
 max_connections = 2000
+error_hook = "jq . >> error.hook"
 
 [apns]
 skip_insecure = true
-key_file = "/path/to/server.key"
-cert_file = "/path/to/server.crt"
-sender_num = 50
-request_per_sec = 2000
-error_hook = "echo -e 'Hello Gunfish at error hook!'"
+key_file = "test/server.key"
+cert_file = "test/server.crt"
+
+[fcm]
+api_key = "FCM_API_KEY"

--- a/const.go
+++ b/const.go
@@ -13,8 +13,6 @@ const (
 const (
 	MaxWorkerNum           = 119   // Maximum of worker number
 	MinWorkerNum           = 1     // Minimum of worker number
-	MaxSenderNum           = 150   // Maximum of sender number
-	MinSenderNum           = 1     // Minimum of sender number
 	MaxQueueSize           = 40960 // Maximum queue size.
 	MinQueueSize           = 128   // Minimum Queue size.
 	MaxRequestSize         = 5000  // Maximum of requset count.
@@ -30,9 +28,10 @@ const (
 	RetryWaitTime = time.Millisecond * 500
 	// RetryOnceCount is the number of sending notification at once.
 	RetryOnceCount = 1000
-	// Default multiplicity of sending notifications to apns. If not configures
-	// at file, this value is set.
-	DefaultApnsSenderNum = 20
+	// multiplicity of sending notifications.
+	SenderNum     = 20
+	RequestPerSec = 2000
+
 	// Default array size of posted data. If not configures at file, this value is set.
 	DefaultRequestQueueSize = 2000
 	// Default port number of provider server

--- a/fcm/client.go
+++ b/fcm/client.go
@@ -80,7 +80,7 @@ func (c *Client) NewRequest(p Payload) (*http.Request, error) {
 }
 
 // NewClient establishes a http connection with fcm
-func NewClient(apikey string, endpoint *url.URL, timeout time.Duration) *Client {
+func NewClient(apikey string, endpoint *url.URL, timeout time.Duration) (*Client, error) {
 	client := &http.Client{
 		Timeout: timeout,
 	}
@@ -92,10 +92,13 @@ func NewClient(apikey string, endpoint *url.URL, timeout time.Duration) *Client 
 
 	if endpoint != nil {
 		c.endpoint = endpoint
-
 	} else {
-		c.endpoint, _ = url.Parse(DefaultFCMEndpoint)
+		if ep, err := url.Parse(DefaultFCMEndpoint); err != nil {
+			return nil, err
+		} else {
+			c.endpoint = ep
+		}
 	}
 
-	return c
+	return c, nil
 }

--- a/server.go
+++ b/server.go
@@ -58,7 +58,7 @@ func StartServer(conf Config, env Environment) {
 	}
 
 	if errorResponseHandler == nil {
-		InitErrorResponseHandler(DefaultResponseHandler{hook: conf.Apns.ErrorHook})
+		InitErrorResponseHandler(DefaultResponseHandler{hook: conf.Provider.ErrorHook})
 	}
 
 	// Init Provider
@@ -137,8 +137,18 @@ func StartServer(conf Config, env Environment) {
 	}).Infof("Starts provider on :%d ...", conf.Provider.Port)
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/push/apns", prov.pushAPNsHandler())
-	mux.HandleFunc("/push/fcm", prov.pushFCMHandler())
+	if conf.Apns.enabled {
+		LogWithFields(logrus.Fields{
+			"type": "provider",
+		}).Infof("Enable endpoint /push/apns")
+		mux.HandleFunc("/push/apns", prov.pushAPNsHandler())
+	}
+	if conf.FCM.enabled {
+		LogWithFields(logrus.Fields{
+			"type": "provider",
+		}).Infof("Enable endpoint /push/fcm")
+		mux.HandleFunc("/push/fcm", prov.pushFCMHandler())
+	}
 	mux.HandleFunc("/stats/app", prov.statsHandler())
 	mux.HandleFunc("/stats/profile", stats_api.Handler)
 

--- a/server_test.go
+++ b/server_test.go
@@ -116,8 +116,8 @@ func TestEnqueueTooManyRequest(t *testing.T) {
 
 	// When queue stack is full, return 503
 	var manyNum int
-	tp := ((config.Provider.RequestQueueSize * int(AverageResponseTime/time.Millisecond)) / 1000) / config.Apns.SenderNum
-	dif := (config.Apns.RequestPerSec - config.Provider.RequestQueueSize/tp)
+	tp := ((config.Provider.RequestQueueSize * int(AverageResponseTime/time.Millisecond)) / 1000) / SenderNum
+	dif := (RequestPerSec - config.Provider.RequestQueueSize/tp)
 	if dif > 0 {
 		manyNum = dif * int(FlowRateInterval/time.Second) * 2
 	} else {

--- a/stat.go
+++ b/stat.go
@@ -15,7 +15,6 @@ type Stats struct {
 	Period                 int64     `json:"period"`
 	RetryAfter             int64     `json:"retry_after"`
 	Workers                int64     `json:"workers"`
-	Senders                int64     `json:"senders"`
 	QueueSize              int64     `json:"queue_size"`
 	RetryQueueSize         int64     `json:"retry_queue_size"`
 	WorkersQueueSize       int64     `json:"workers_queue_size"`

--- a/supervisor_test.go
+++ b/supervisor_test.go
@@ -91,7 +91,7 @@ func TestEnqueuRequestToSupervisor(t *testing.T) {
 	etr := TestResponseHandler{
 		wg:         &wg,
 		scoreboard: score,
-		hook:       config.Apns.ErrorHook,
+		hook:       config.Provider.ErrorHook,
 	}
 	str := TestResponseHandler{
 		wg:         &wg,

--- a/test/gunfish_test.toml
+++ b/test/gunfish_test.toml
@@ -4,6 +4,7 @@ worker_num = 8
 queue_size = 2000
 max_request_size = 1000
 max_connections = 2000
+error_hook = "cat "
 
 [apns]
 skip_insecure = true
@@ -11,7 +12,6 @@ key_file = "./test/server.key"
 cert_file = "./test/server.crt"
 sender_num = 50
 request_per_sec = 2000
-error_hook = "cat "
 
 [fcm]
 api_key = 'fcm_test_api_key'


### PR DESCRIPTION
This PR includes below.

- Move `error_hook` from [apns] section to [provider] section.
  - `error_hook` is used for APNs and FCM both.
- Remove Senders and RequestPerSec from config.
  - There were not necessary to customize in real workload.
- If [apns] section is not present, /push/apns API endpoint returns 404. (same for [fcm] section)
