### PR TITLE
fix: assignment copies lock value to *tlsConf

### DIFF
--- a/apns/mock_server.go
+++ b/apns/mock_server.go
@@ -28,7 +28,7 @@ func StartAPNSMockServer(cert, key string) {
 	http2.ConfigureServer(&s, nil)
 	tlsConf := &tls.Config{}
 	if s.TLSConfig != nil {
-		*tlsConf = *s.TLSConfig
+		tlsConf = s.TLSConfig.Clone()
 	}
 	if tlsConf.NextProtos == nil {
 		tlsConf.NextProtos = []string{"http/2.0"}


### PR DESCRIPTION
related to https://github.com/golang/go/issues/15771

`s.TLSConfig` contains `sync.Mutex` and `sync.Once`, so it must not be copied.
