### PR TITLE
Fix response when request a invalid json to /push/fcm

### DIFF
--- a/server.go
+++ b/server.go
@@ -271,6 +271,7 @@ func (prov *Provider) pushFCMHandler() http.HandlerFunc {
 			logrus.Warnf("Internal Server Error: %s", err)
 			res.WriteHeader(http.StatusInternalServerError)
 			fmt.Fprintf(res, "{\"reason\":\"%s\"}", err.Error())
+			return
 		}
 		grs := []Request{
 			Request{

--- a/server_test.go
+++ b/server_test.go
@@ -194,7 +194,7 @@ func TestTooLargeRequest(t *testing.T) {
 	sup.Shutdown()
 }
 
-func TestMethodNotAllowd(t *testing.T) {
+func TestMethodNotAllowed(t *testing.T) {
 	sup, _ := StartSupervisor(&config)
 	prov := &Provider{sup: sup}
 	handler := prov.pushAPNsHandler()

--- a/server_test.go
+++ b/server_test.go
@@ -152,7 +152,7 @@ func TestEnqueueTooManyRequest(t *testing.T) {
 		t.Errorf("Expected status code is 503 but got %d", w.Code)
 	}
 	if w.Header().Get("Retry-After") == "" {
-		t.Errorf("Not set Retry-After correctlly: ", w.Header().Get("Retry-After"))
+		t.Error("Not set Retry-After correctlly")
 	}
 
 	// Test Retry-After value increases

--- a/server_test.go
+++ b/server_test.go
@@ -66,6 +66,30 @@ func TestSuccessToPostJson(t *testing.T) {
 	sup.Shutdown()
 }
 
+func TestFailedToPostInvalidJson(t *testing.T) {
+	sup, _ := StartSupervisor(&config)
+	prov := &Provider{sup: sup}
+	handler := prov.pushFCMHandler()
+
+	// missing `}`
+	invalidJson := []byte(`{"registration_ids": ["xxxxxxxxx"], "data": {"message":"test"`)
+
+	w := httptest.NewRecorder()
+	r, err := newRequest(invalidJson, "POST", ApplicationJSON)
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+
+	handler.ServeHTTP(w, r)
+
+	invalidResponse := bytes.NewBufferString("{\"reason\":\"unexpected EOF\"}{\"result\": \"ok\"}").String()
+	if w.Body.String() == invalidResponse {
+		t.Errorf("Invalid Json responce: '%s'", w.Body)
+	}
+
+	sup.Shutdown()
+}
+
 func TestFailedToPostMalformedJson(t *testing.T) {
 	sup, _ := StartSupervisor(&config)
 	prov := &Provider{sup: sup}


### PR DESCRIPTION
- When request a invalid json to `/push/fcm`, API respose is invalid.

ex)
```bash
curl -X POST -H "Content-type: application/json" -d '{"registration_ids": ["xxxxxxxxx"], "data": {"messege":"hoge"}' http://localhost:8003/push/fcm
{"reason":"unexpected EOF"}{"result": "ok"}
```

- Fix `./server_test.go:155: Errorf call has arguments but no formatting directives`
- Fix typo