### PR TITLE
Feature/log output option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ option             | required | description
 -------------------|----------|------------------------------------------------------------------------------------------------------------------
 -port              | Optional | Port number of Gunfish provider server. Default is `8003`.
 -environment, -E   | Optional | Default value is `production`.
--conf, -c          | Optional | Set a string where you want to write the log message such as a file (specified path), 'stdout', 'stderr', or 'discard'. By default, leave it to 'github.com/sirupsen/logrus'.
--log-output        | Optional | Please specify the log file path or `stdout`, `stderr` and `discard` where you want to output the log message. By default, leave it to `github.com/sirupsen/logrus`.
+-conf, -c          | Optional | Please specify this option if you want to change `toml` config file path. (default: `/etc/gunfish/config.toml`.)
+-log-output        | Optional | Set a string where you want to write the log message such as a file (specified path), 'stdout', 'stderr', or 'discard'. By default, leave it to 'github.com/sirupsen/logrus'.
 -log-level         | Optional | Set the log level as 'warn', 'info', or 'debug'.
 -log-format        | Optional | Supports `json` or `ltsv` log formats.
 -enable-pprof      | Optional | You can set the flag of pprof debug port open.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ option             | required | description
 -------------------|----------|------------------------------------------------------------------------------------------------------------------
 -port              | Optional | Port number of Gunfish provider server. Default is `8003`.
 -environment, -E   | Optional | Default value is `production`.
--conf, -c          | Optional | Please specify this option if you want to change `toml` config file path. (default: `/etc/gunfish/config.toml`.)
+-conf, -c          | Optional | Set a string where you want to write the log message such as a file (specified path), 'stdout', 'stderr', or 'discard'. By default, leave it to 'github.com/sirupsen/logrus'.
+-log-output        | Optional | Please specify the log file path or `stdout`, `stderr` and `discard` where you want to output the log message. By default, leave it to `github.com/sirupsen/logrus`.
 -log-level         | Optional | Set the log level as 'warn', 'info', or 'debug'.
 -log-format        | Optional | Supports `json` or `ltsv` log formats.
 -enable-pprof      | Optional | You can set the flag of pprof debug port open.

--- a/cmd/gunfish/gunfish.go
+++ b/cmd/gunfish/gunfish.go
@@ -130,7 +130,7 @@ func initLogrus(logOutput string, format string, logLevel string) {
 		if err == nil {
 			logrus.SetOutput(file)
 		} else {
-			logrus.Info("Failed to log to file, using default stderr")
+			logrus.Info("Failed to log to file, using default")
 		}
 	}
 

--- a/cmd/gunfish/gunfish.go
+++ b/cmd/gunfish/gunfish.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/pprof"
@@ -19,25 +20,26 @@ var version string
 func main() {
 	var (
 		config      string
+		enablePprof bool
 		environment string
 		logFormat   string
-		port        int
-		enablePprof bool
-		showVersion bool
 		logLevel    string
+		logOutput   string
+		port        int
+		showVersion bool
 	)
 
-	flag.StringVar(&config, "config", "/etc/gunfish/config.toml", "specify config file.")
-	flag.StringVar(&config, "c", "/etc/gunfish/config.toml", "specify config file.")
-	flag.StringVar(&environment, "environment", "production", "APNS environment. (production, development, or test)")
 	flag.StringVar(&environment, "E", "production", "APNS environment. (production, development, or test)")
-	flag.IntVar(&port, "port", 0, "Gunfish port number (range 1024-65535).")
-	flag.StringVar(&logFormat, "log-format", "", "specifies the log format: ltsv or json.")
+	flag.StringVar(&config, "c", "/etc/gunfish/config.toml", "specify config file.")
+	flag.StringVar(&config, "config", "/etc/gunfish/config.toml", "specify config file.")
 	flag.BoolVar(&enablePprof, "enable-pprof", false, ".")
+	flag.StringVar(&environment, "environment", "production", "APNS environment. (production, development, or test)")
+	flag.StringVar(&logFormat, "log-format", "", "specifies the log format: ltsv or json.")
+	flag.StringVar(&logLevel, "log-level", "info", "set the log level (debug, warn, info)")
+	flag.StringVar(&logOutput, "log-output", "", "set a string where you want to write the log message such as a file (specified path), 'stdout', 'stderr', or 'discard'. By default, leave it to 'github.com/sirupsen/logrus'.")
+	flag.IntVar(&port, "port", 0, "Gunfish port number (range 1024-65535).")
 	flag.BoolVar(&showVersion, "v", false, "show version number.")
 	flag.BoolVar(&showVersion, "version", false, "show version number.")
-
-	flag.StringVar(&logLevel, "log-level", "info", "set the log level (debug, warn, info)")
 	flag.Parse()
 
 	if showVersion {
@@ -46,7 +48,7 @@ func main() {
 		return
 	}
 
-	initLogrus(logFormat, logLevel)
+	initLogrus(logOutput, logFormat, logLevel)
 
 	c, err := gunfish.LoadConfig(config)
 	if err != nil {
@@ -106,7 +108,7 @@ func main() {
 	gunfish.StartServer(c, env)
 }
 
-func initLogrus(format string, logLevel string) {
+func initLogrus(logOutput string, format string, logLevel string) {
 	switch format {
 	case "ltsv":
 		logrus.SetFormatter(&gunfish.LtsvFormatter{})
@@ -114,10 +116,27 @@ func initLogrus(format string, logLevel string) {
 		logrus.SetFormatter(&logrus.JSONFormatter{})
 	}
 
+	switch logOutput {
+	case "":
+		// do nothing
+	case "stdout":
+		logrus.SetOutput(os.Stdout)
+	case "stderr":
+		logrus.SetOutput(os.Stderr)
+	case "discard":
+		logrus.SetOutput(ioutil.Discard)
+	default:
+		file, err := os.OpenFile(logOutput, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+		if err == nil {
+			logrus.SetOutput(file)
+		} else {
+			logrus.Info("Failed to log to file, using default stderr")
+		}
+	}
+
 	lvl, err := logrus.ParseLevel(logLevel)
 	if err != nil {
 		lvl = logrus.InfoLevel
 	}
-
 	logrus.SetLevel(lvl)
 }


### PR DESCRIPTION
I would like to select where we want to write the log message such as a file (specified path), `stdout`, `stderr`, or `discard`, which I implemented.
Incidentally, Gunfish leaves it to [github.com/sirupsen/logrus](https://github.com/sirupsen/logrus) by default.