### PR TITLE
support environment variables on config file

### DIFF
--- a/config.go
+++ b/config.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/BurntSushi/toml"
+	goconf "github.com/kayac/go-config"
 	"github.com/sirupsen/logrus"
 )
 
@@ -53,7 +53,7 @@ func DefaultLoadConfig() (Config, error) {
 func LoadConfig(fn string) (Config, error) {
 	var config Config
 
-	if _, err := toml.DecodeFile(fn, &config); err != nil {
+	if err := goconf.LoadWithEnvTOML(&config, fn); err != nil {
 		LogWithFields(logrus.Fields{"type": "load_config"}).Warnf("%v %s %s", config, err, fn)
 		return config, err
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -1,13 +1,21 @@
 package gunfish
 
 import (
+	"os"
 	"testing"
 )
 
 func TestLoadTomlConfigFile(t *testing.T) {
-	_, err := LoadConfig("./test/gunfish_test.toml")
+	if err := os.Setenv("TEST_GUNFISH_HOOK_CMD", "cat | grep test"); err != nil {
+		t.Error(err)
+	}
 
+	c, err := LoadConfig("./test/gunfish_test.toml")
 	if err != nil {
 		t.Error(err)
+	}
+
+	if g, w := c.Provider.ErrorHook, "cat | grep test"; g != w {
+		t.Errorf("not match error hook: got %s want %s", g, w)
 	}
 }

--- a/test/gunfish_test.toml
+++ b/test/gunfish_test.toml
@@ -4,7 +4,7 @@ worker_num = 8
 queue_size = 2000
 max_request_size = 1000
 max_connections = 2000
-error_hook = "cat "
+error_hook = "{{ env `TEST_GUNFISH_HOOK_CMD` `cat ` }}"
 
 [apns]
 skip_insecure = true


### PR DESCRIPTION
We would like to manage a gunfish config file not to embed the fcm api key.
Using [kayac/go-config](https://github.com/kayac/go-config), it supports to embed environment variables.