### PR TITLE
modify dockerfile for v0.2.6

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,10 +3,10 @@ MAINTAINER Fujiwara Shunichiro <fujiwara.shunichiro@gmail.com>
 
 RUN apk --no-cache add unzip curl && \
     mkdir -p /etc/gunfish /opt/gunfish && \
-    curl -sL https://github.com/kayac/Gunfish/releases/download/v0.2.4/gunfish-v0.2.4-linux-amd64.zip > /tmp/gunfish-v0.2.4-linux-amd64.zip && \
+    curl -sL https://github.com/kayac/Gunfish/releases/download/v0.2.6/gunfish-v0.2.6-linux-amd64.zip > /tmp/gunfish-v0.2.6-linux-amd64.zip && \
     cd /tmp && \
-    unzip gunfish-v0.2.4-linux-amd64.zip && \
-    install gunfish-v0.2.4-linux-amd64 /usr/bin/gunfish && \
+    unzip gunfish-v0.2.6-linux-amd64.zip && \
+    install gunfish-v0.2.6-linux-amd64 /usr/bin/gunfish && \
     rm -f /tmp/gunfish*
 
 WORKDIR /opt/gunfish


### PR DESCRIPTION
#35 
As dockerfile's release file version was v0.2.4, modify v0.2.6.

That should be dynamically but tag v0.2.6 docker hub image is not working, so change v0.2.4 -> v0.2.6. Then, re-create tag v0.2.6 after merge to master.