### PR TITLE
Modify to build static linked

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,13 @@ get-deps:
 	dep ensure
 
 packages:
-	cd cmd/gunfish && gox -os="linux darwin" -arch="amd64" -output "../../pkg/{{.Dir}}-${GIT_VER}-{{.OS}}-{{.Arch}}" -gcflags "-trimpath=${GOPATH}" -ldflags "-w -X main.version=${GIT_VER} -X main.buildDate=${DATE}"
+	cd cmd/gunfish && gox \
+					-os="linux darwin" \
+					-arch="amd64" \
+					-output "../../pkg/{{.Dir}}-${GIT_VER}-{{.OS}}-{{.Arch}}" \
+					-gcflags "-trimpath=${GOPATH}" \
+					-ldflags "-w -X main.version=${GIT_VER} -X main.buildDate=${DATE} -extldflags \"-static\"" \
+					-tags "netgo"
 	cd pkg && find . -name "*${GIT_VER}*" -type f -exec zip {}.zip {} \;
 
 gen-cert:

--- a/Makefile
+++ b/Makefile
@@ -18,12 +18,12 @@ get-deps:
 
 packages:
 	cd cmd/gunfish && gox \
-					-os="linux darwin" \
-					-arch="amd64" \
-					-output "../../pkg/{{.Dir}}-${GIT_VER}-{{.OS}}-{{.Arch}}" \
-					-gcflags "-trimpath=${GOPATH}" \
-					-ldflags "-w -X main.version=${GIT_VER} -X main.buildDate=${DATE} -extldflags \"-static\"" \
-					-tags "netgo"
+		-os="linux darwin" \
+		-arch="amd64" \
+		-output "../../pkg/{{.Dir}}-${GIT_VER}-{{.OS}}-{{.Arch}}" \
+		-gcflags "-trimpath=${GOPATH}" \
+		-ldflags "-w -X main.version=${GIT_VER} -X main.buildDate=${DATE} -extldflags \"-static\"" \
+		-tags "netgo"
 	cd pkg && find . -name "*${GIT_VER}*" -type f -exec zip {}.zip {} \;
 
 gen-cert:

--- a/Makefile
+++ b/Makefile
@@ -17,13 +17,14 @@ get-deps:
 	dep ensure
 
 packages:
-	cd cmd/gunfish && gox \
-		-os="linux darwin" \
-		-arch="amd64" \
-		-output "../../pkg/{{.Dir}}-${GIT_VER}-{{.OS}}-{{.Arch}}" \
-		-gcflags "-trimpath=${GOPATH}" \
-		-ldflags "-w -X main.version=${GIT_VER} -X main.buildDate=${DATE} -extldflags \"-static\"" \
-		-tags "netgo"
+	cd cmd/gunfish \
+		&& CGO_ENABLED=0 gox \
+			-os="linux darwin" \
+			-arch="amd64" \
+			-output "../../pkg/{{.Dir}}-${GIT_VER}-{{.OS}}-{{.Arch}}" \
+			-gcflags "-trimpath=${GOPATH}" \
+			-ldflags "-w -X main.version=${GIT_VER} -X main.buildDate=${DATE} -extldflags \"-static\"" \
+			-tags "netgo"
 	cd pkg && find . -name "*${GIT_VER}*" -type f -exec zip {}.zip {} \;
 
 gen-cert:


### PR DESCRIPTION
v0.2.6 binary is dynamic linked, so gunfish binary is not found in container.
```
 » ldd gunfish-v0.2.6-linux-amd64
	linux-vdso.so.1 (0x00007ffe7aba2000)
	libpthread.so.0 => /usr/lib/libpthread.so.0 (0x00007f99495fb000)
	libc.so.6 => /usr/lib/libc.so.6 (0x00007f994923f000)
	/lib64/ld-linux-x86-64.so.2 => /usr/lib64/ld-linux-x86-64.so.2 (0x00007f9949819000)
```

So, make binary to statically link.
```
» ldd gunfish-v0.2.6-5-linux-amd64
	not a dynamic executable
```
I'll delete v0.2.6-5 and re-create v0.2.6 after to merge.

check in container:
```
$ docker run -it --entrypoint="" kayac/gunfish:v0.2.6-5 /bin/sh

/opt/gunfish # ldd /usr/bin/gunfish 
ldd: /usr/bin/gunfish: Not a valid dynamic program
```