### PR TITLE
fix uuid function to follow changing return value

### DIFF
--- a/supervisor.go
+++ b/supervisor.go
@@ -456,7 +456,7 @@ func spawnSender(wq <-chan Request, respq chan<- SenderResponse, wgrp *sync.Wait
 				RespTime: respTime,
 				Req:      req, // Must copy
 				Err:      err,
-				UID:      uuid.NewV4().String(),
+				UID:      uuid.Must(uuid.NewV4()).String(),
 			}
 		case fcm.Payload:
 			if fc == nil {
@@ -477,7 +477,7 @@ func spawnSender(wq <-chan Request, respq chan<- SenderResponse, wgrp *sync.Wait
 				RespTime: respTime,
 				Req:      req,
 				Err:      err,
-				UID:      uuid.NewV4().String(),
+				UID:      uuid.Must(uuid.NewV4()).String(),
 			}
 		default:
 			LogWithFields(logrus.Fields{"type": "sender"}).


### PR DESCRIPTION
satori/go.uuid NewV4 change multiple return value
https://github.com/satori/go.uuid/commit/0ef6afb2f6cdd6cdaeee3885a95099c63f18fc8c
So, make test failed outputing following the message
```
$make test
...
./supervisor.go:459:25: multiple-value uuid.NewV4() in single-value context
./supervisor.go:480:25: multiple-value uuid.NewV4() in single-value context
FAIL    _/home/u5surf/Gunfish [build failed]
make: *** [test] エラー 1
```
therefore, i change this function into uuid.Must(uuid.NewV4())