### PR TITLE
Support apns provider authentication

### DIFF
--- a/apns/client.go
+++ b/apns/client.go
@@ -39,7 +39,7 @@ type Client struct {
 	authToken    authToken
 	kid          string
 	teamID       string
-	keyFile      string
+	key          []byte
 	useAuthToken bool
 }
 
@@ -128,7 +128,7 @@ func (ac *Client) issueToken() error {
 	var err error
 	now := time.Now()
 
-	ac.authToken.jwt, err = CreateJWT(ac.keyFile, ac.kid, ac.teamID, now)
+	ac.authToken.jwt, err = CreateJWT(ac.key, ac.kid, ac.teamID, now)
 	if err != nil {
 		return err
 	}
@@ -161,6 +161,11 @@ func NewClient(conf config.SectionApns) (*Client, error) {
 		return nil, err
 	}
 
+	key, err := ioutil.ReadFile(conf.KeyFile)
+	if err != nil {
+		return nil, err
+	}
+
 	client := &Client{
 		Host: conf.Host,
 		client: &http.Client{
@@ -169,7 +174,7 @@ func NewClient(conf config.SectionApns) (*Client, error) {
 		},
 		kid:          conf.Kid,
 		teamID:       conf.TeamID,
-		keyFile:      conf.KeyFile,
+		key:          key,
 		useAuthToken: useAuthToken,
 	}
 	if client.useAuthToken {

--- a/apns/jwt.go
+++ b/apns/jwt.go
@@ -76,10 +76,12 @@ func CreateJWT(keyFile string, kid string, teamID string, now time.Time) (string
 
 func writeAsBase64(w io.Writer, byt []byte) error {
 	enc := base64.NewEncoder(base64.RawURLEncoding, w)
+	defer enc.Close()
+
 	if _, err := enc.Write(byt); err != nil {
 		return err
 	}
-	return enc.Close()
+	return nil
 }
 
 func createSignature(payload []byte, keyFile string) ([]byte, error) {

--- a/apns/jwt.go
+++ b/apns/jwt.go
@@ -18,6 +18,8 @@ import (
 
 // https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CommunicatingwithAPNs.html#//apple_ref/doc/uid/TP40008194-CH11-SW1
 
+const jwtDefaultGrowSize = 256
+
 type jwtHeader struct {
 	Alg string `json:"alg"`
 	Kid string `json:"kid"`
@@ -33,8 +35,8 @@ type ecdsaSignature struct {
 }
 
 func CreateJWT(keyFile string, kid string, teamID string, now time.Time) (string, error) {
-
 	var b bytes.Buffer
+	b.Grow(jwtDefaultGrowSize)
 
 	header := jwtHeader{
 		Alg: "ES256",
@@ -47,7 +49,7 @@ func CreateJWT(keyFile string, kid string, teamID string, now time.Time) (string
 	if err := writeAsBase64(&b, headerJSON); err != nil {
 		return "", err
 	}
-	b.WriteString(".")
+	b.WriteByte(byte('.'))
 
 	claim := jwtClaim{
 		Iss: teamID,
@@ -65,7 +67,7 @@ func CreateJWT(keyFile string, kid string, teamID string, now time.Time) (string
 	if err != nil {
 		return "", err
 	}
-	b.WriteString(".")
+	b.WriteByte(byte('.'))
 
 	if err := writeAsBase64(&b, sig); err != nil {
 		return "", err

--- a/apns/jwt.go
+++ b/apns/jwt.go
@@ -1,0 +1,113 @@
+package apns
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/asn1"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"io"
+	"io/ioutil"
+	"math/big"
+	"time"
+)
+
+// https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CommunicatingwithAPNs.html#//apple_ref/doc/uid/TP40008194-CH11-SW1
+
+type jwtHeader struct {
+	Alg string `json:"alg"`
+	Kid string `json:"kid"`
+}
+
+type jwtClaim struct {
+	Iss string `json:"iss"`
+	Iat int64  `json:"iat"`
+}
+
+type ecdsaSignature struct {
+	R, S *big.Int
+}
+
+func CreateJWT(keyFile string, kid string, teamID string, now time.Time) (string, error) {
+
+	var b bytes.Buffer
+
+	header := jwtHeader{
+		Alg: "ES256",
+		Kid: kid,
+	}
+	headerJSON, err := json.Marshal(&header)
+	if err != nil {
+		return "", err
+	}
+	if err := writeAsBase64(&b, headerJSON); err != nil {
+		return "", err
+	}
+	b.WriteString(".")
+
+	claim := jwtClaim{
+		Iss: teamID,
+		Iat: now.Unix(),
+	}
+	claimJSON, err := json.Marshal(&claim)
+	if err != nil {
+		return "", err
+	}
+	if err := writeAsBase64(&b, claimJSON); err != nil {
+		return "", err
+	}
+
+	sig, err := createSignature(b.Bytes(), keyFile)
+	if err != nil {
+		return "", err
+	}
+	b.WriteString(".")
+
+	if err := writeAsBase64(&b, sig); err != nil {
+		return "", err
+	}
+
+	return b.String(), nil
+}
+
+func writeAsBase64(w io.Writer, byt []byte) error {
+	enc := base64.NewEncoder(base64.RawURLEncoding, w)
+	if _, err := enc.Write(byt); err != nil {
+		return err
+	}
+	return enc.Close()
+}
+
+func createSignature(payload []byte, keyFile string) ([]byte, error) {
+	h := crypto.SHA256.New()
+	if _, err := h.Write(payload); err != nil {
+		return nil, err
+	}
+	msg := h.Sum(nil)
+
+	data, err := ioutil.ReadFile(keyFile)
+	if err != nil {
+		return nil, err
+	}
+	block, _ := pem.Decode(data)
+	key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+
+	r, s, err := ecdsa.Sign(rand.Reader, key.(*ecdsa.PrivateKey), msg)
+	if err != nil {
+		return nil, err
+	}
+
+	sig, err := asn1.Marshal(ecdsaSignature{r, s})
+	if err != nil {
+		return nil, err
+	}
+
+	return sig, nil
+}

--- a/stat.go
+++ b/stat.go
@@ -44,6 +44,8 @@ func (st *Stats) GetStats() *Stats {
 	preUptime := st.Uptime
 	st.Uptime = time.Now().Unix() - st.StartAt
 	st.Period = st.Uptime - preUptime
-	st.CertificateExpireUntil = int64(st.CertificateNotAfter.Sub(time.Now()).Seconds())
+	if !st.CertificateNotAfter.IsZero() {
+		st.CertificateExpireUntil = int64(st.CertificateNotAfter.Sub(time.Now()).Seconds())
+	}
 	return st
 }

--- a/supervisor.go
+++ b/supervisor.go
@@ -2,6 +2,7 @@ package gunfish
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -159,7 +160,7 @@ func StartSupervisor(conf *config.Config) (Supervisor, error) {
 			fc *fcm.Client
 		)
 		if conf.Apns.Enabled {
-			ac, err = apns.NewClient(conf.Apns.Host, conf.Apns.CertFile, conf.Apns.KeyFile)
+			ac, err = apns.NewClient(conf.Apns)
 			if err != nil {
 				LogWithFields(logrus.Fields{
 					"type": "supervisor",
@@ -334,24 +335,7 @@ func handleAPNsResponse(resp SenderResponse, retryq chan<- Request, cmdq chan Co
 			onResponse(result, errorResponseHandler.HookCmd(), cmdq)
 		} else {
 			// if 'result' is nil, HTTP connection error with APNS.
-			LogWithFields(logf).Warnf("response is nil. reason: %s", resp.Err.Error())
-			if req.Tries < SendRetryCount {
-				req.Tries++
-				atomic.AddInt64(&(srvStats.RetryCount), 1)
-				logf["resend_cnt"] = req.Tries
-
-				select {
-				case retryq <- req:
-					LogWithFields(logf).
-						Debugf("Retry to enqueue into retryq because of http connection error with APNS.")
-				default:
-					LogWithFields(logf).
-						Warnf("Supervisor retry queue is full.")
-				}
-			} else {
-				LogWithFields(logf).
-					Warnf("Retry count is over than %d. Could not deliver notification.", SendRetryCount)
-			}
+			retry(retryq, req, errors.New("http connection error between APNs"), logf)
 		}
 	} else {
 		atomic.AddInt64(&(srvStats.SentCount), 1)
@@ -362,6 +346,12 @@ func handleAPNsResponse(resp SenderResponse, retryq chan<- Request, cmdq chan Co
 			}
 			if err := result.Err(); err != nil {
 				atomic.AddInt64(&(srvStats.ErrCount), 1)
+
+				// retry when provider auhentication token is expired
+				if err.Error() == apns.ExpiredProviderToken.String() {
+					retry(retryq, req, err, logf)
+				}
+
 				onResponse(result, errorResponseHandler.HookCmd(), cmdq)
 				LogWithFields(logf).Errorf("%s", err)
 			} else {
@@ -571,4 +561,24 @@ func invokePipe(hook string, src io.Reader) ([]byte, error) {
 
 	err = cmd.Run()
 	return b.Bytes(), err
+}
+
+func retry(retryq chan<- Request, req Request, err error, logf logrus.Fields) {
+	if req.Tries < SendRetryCount {
+		req.Tries++
+		atomic.AddInt64(&(srvStats.RetryCount), 1)
+		logf["resend_cnt"] = req.Tries
+
+		select {
+		case retryq <- req:
+			LogWithFields(logf).
+				Debugf("%s: Retry to enqueue into retryq.", err.Error())
+		default:
+			LogWithFields(logf).
+				Warnf("Supervisor retry queue is full.")
+		}
+	} else {
+		LogWithFields(logf).
+			Warnf("Retry count is over than %d. Could not deliver notification.", SendRetryCount)
+	}
 }


### PR DESCRIPTION
ref #42
recreate pr to seperate config refactoring and provider authentication.

> ref https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CommunicatingwithAPNs.html
> 
> Support apns provider authentication token because I want to save time to update the ciertification.
> 
> In apns specification, jwt is expired on hour and apns returns the expired error (ExpireProviderToken).
> So, I deal with it below:
> 
> - update jwt token less than one hour ago
> - resend when ExpireProviderToken
>
> I'll fix test code other pr.