### PR TITLE
Error hook payload outputs to stdout/stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Response example:
   "queue_size": 0,
   "retry_queue_size": 0,
   "workers_queue_size": 0,
-  "cmdq_queue_size": 0,
+  "error_queue_size": 0,
   "retry_count": 0,
   "req_count": 0,
   "sent_count": 0,
@@ -143,7 +143,7 @@ start\_at | The time of started
 queue\_size | queue size of requests
 retry\_queue\_size | queue size for resending notification
 workers\_queue\_size | summary of worker's queue size
-command\_queue\_size | error hook command queue size
+error\_queue\_size | error hook command queue size
 retry\_count | summary of retry count
 request\_count | request count to gunfish
 err\_count | count of recieving error response
@@ -193,11 +193,13 @@ cert_file        |optional| The cert file path.
 kid              |optional| kid for APNs provider authentication token.
 team_id          |optional| team id for APNs provider authentication token.
 error_hook       |optional| Error hook command. This command runs when Gunfish catches an error response.
+error_hook_to    |optional| Error hook outputs into stdout/stderr.
 api_key          |optional| FCM api key. If you want to delivery notifications to android, it is required.
 
-## Error Hook
+## Error Hook payload
 
-Error hook command can get an each error response with JSON format by STDIN.
+Error hook command/stdout/stderr will get an each error response with JSON format.
+The command accepts a payload by STDIN.
 
 for example JSON structure: (>= v0.2.x)
 ```json5
@@ -265,41 +267,9 @@ $ go get github.com/lestrrat/go-server-starter/cmd/start_server
 $ start_server --port 38003 --pid-file gunfish.pid -- ./gunfish -c conf/gunfish.toml
 ```
 
-## Customize
-
-### How to Implement Response Handlers
-
-If you have to handle something on error or on success, you should implement error or success handlers.
-For example handlers you should implement is given below:
-
-```go
-type CustomYourErrorHandler struct {
-    hookCmd string
-}
-
-func (ch CustomYourErrorHandler) OnResponse(result Result){
-    // ...
-}
-
-func (ch CustomYourErrorHandler) HookCmd( ) string {
-    return ch.hookCmd
-}
-```
-
-Then you can use these handlers to set before to start gunfish server `( gunfish.StartServer( Config, Environment ) )`.
-
-```go
-InitErrorResponseHandler(CustomYourErrorHandler{hookCmd: "echo 'on error!'"})
-```
-
-You can implement a success custom handler in the same way but a hook command is not executed in the success handler in order not to make cpu resource too tight.
-
 ### Test
 
-Requires [dep](https://github.com/golang/dep/) for vendoring.
-
 ```
-$ make get-deps
 $ make test
 ```
 

--- a/README.md
+++ b/README.md
@@ -183,18 +183,18 @@ api_key = "API key for FCM"
 
 param            | status | description
 ---------------- | ------ | --------------------------------------------------------------------------------------
-port             |optional| Listen port number.
-worker_num       |optional| Number of Gunfish owns http clients.
-queue_size       |optional| Limit number of posted JSON from the developer application.
-max_request_size |optional| Limit size of Posted JSON array.
-max_connections  |optional| Max connections
-key_file         |required| The key file path.
-cert_file        |optional| The cert file path.
-kid              |optional| kid for APNs provider authentication token.
-team_id          |optional| team id for APNs provider authentication token.
-error_hook       |optional| Error hook command. This command runs when Gunfish catches an error response.
-error_hook_to    |optional| Error hook outputs into stdout/stderr.
-api_key          |optional| FCM api key. If you want to delivery notifications to android, it is required.
+port               |optional| Listen port number.
+worker\_num        |optional| Number of Gunfish owns http clients.
+queue_size         |optional| Limit number of posted JSON from the developer application.
+max\_request\_size |optional| Limit size of Posted JSON array.
+max\_connections   |optional| Max connections
+key\_file          |required| The key file path.
+cert\_file         |optional| The cert file path.
+kid                |optional| kid for APNs provider authentication token.
+team\_id           |optional| team id for APNs provider authentication token.
+error\_hook        |optional| Error hook command. This command runs when Gunfish catches an error response.
+error\_hook\_to    |optional| Error hook outputs into stdout/stderr.
+api\_key           |optional| FCM api key. If you want to delivery notifications to android, it is required.
 
 ## Error Hook payload
 

--- a/config/config.go
+++ b/config/config.go
@@ -45,6 +45,7 @@ type SectionProvider struct {
 	DebugPort        int
 	MaxConnections   int    `toml:"max_connections"`
 	ErrorHook        string `toml:"error_hook"`
+	ErrorHookTo      string `toml:"error_hook_to"`
 }
 
 // SectionApns is the configure which is loaded from gunfish.toml

--- a/server.go
+++ b/server.go
@@ -34,7 +34,6 @@ type Provider struct {
 // Therefore, you can specifies hook command which is set at toml file.
 type ResponseHandler interface {
 	OnResponse(Result)
-	HookCmd() string
 }
 
 // DefaultResponseHandler is the default ResponseHandler if not specified.
@@ -46,12 +45,6 @@ type DefaultResponseHandler struct {
 func (rh DefaultResponseHandler) OnResponse(result Result) {
 }
 
-// HookCmd returns hook command to execute after getting response from APNS
-// only when to get error response.
-func (rh DefaultResponseHandler) HookCmd() string {
-	return rh.Hook
-}
-
 // StartServer starts an apns provider server on http.
 func StartServer(conf config.Config, env Environment) {
 	// Initialize DefaultResponseHandler if response handlers are not defined.
@@ -60,7 +53,7 @@ func StartServer(conf config.Config, env Environment) {
 	}
 
 	if errorResponseHandler == nil {
-		InitErrorResponseHandler(DefaultResponseHandler{Hook: conf.Provider.ErrorHook})
+		InitErrorResponseHandler(DefaultResponseHandler{})
 	}
 
 	// Init Provider
@@ -337,7 +330,7 @@ func (prov *Provider) StatsHandler() http.HandlerFunc {
 		atomic.StoreInt64(&(srvStats.QueueSize), int64(len(prov.Sup.queue)))
 		atomic.StoreInt64(&(srvStats.RetryQueueSize), int64(len(prov.Sup.retryq)))
 		atomic.StoreInt64(&(srvStats.WorkersQueueSize), int64(wqs))
-		atomic.StoreInt64(&(srvStats.CommandQueueSize), int64(len(prov.Sup.cmdq)))
+		atomic.StoreInt64(&(srvStats.ErrorQueueSize), int64(len(prov.Sup.errq)))
 		res.WriteHeader(http.StatusOK)
 		encoder := json.NewEncoder(res)
 		err := encoder.Encode(srvStats.GetStats())

--- a/stat.go
+++ b/stat.go
@@ -20,7 +20,7 @@ type Stats struct {
 	QueueSize              int64     `json:"queue_size"`
 	RetryQueueSize         int64     `json:"retry_queue_size"`
 	WorkersQueueSize       int64     `json:"workers_queue_size"`
-	CommandQueueSize       int64     `json:"cmdq_queue_size"`
+	ErrorQueueSize         int64     `json:"error_queue_size"`
 	RetryCount             int64     `json:"retry_count"`
 	RequestCount           int64     `json:"req_count"`
 	SentCount              int64     `json:"sent_count"`


### PR DESCRIPTION
Add `error_hook_to` configuration which enable to output error hook payload to stdout/stderr.

Now `cmdq` channel and `Command` struct names are  not suitable name, I renamed these names to `errq` and `Error`. (This is backward breaking change.)