### PR TITLE
Allow multiple payload in fcm/v1 request body.

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ Response example:
 {"result": "ok"}
 ```
 
+FCM v1 endpoint allows multiple payloads in a single request body. You can build request body simply concat multiple JSON payloads. Gunfish sends for each that payloads to FCM server. Limitation: Max count of payloads in a request body is 500.
+
 ### GET /stats/app
 
 ```json

--- a/fcmv1/request.go
+++ b/fcmv1/request.go
@@ -8,3 +8,6 @@ import (
 type Payload struct {
 	Message messaging.Message `json:"message"`
 }
+
+// MaxBulkRequests represens max count of request payloads in a request body.
+const MaxBulkRequests = 500

--- a/supervisor_test.go
+++ b/supervisor_test.go
@@ -99,7 +99,7 @@ func TestEnqueuRequestToSupervisor(t *testing.T) {
 	for range []int{0, 1, 2, 3, 4, 5, 6} {
 		sup.EnqueueClientRequest(&reqs)
 	}
-	time.Sleep(time.Millisecond * 500)
+	time.Sleep(time.Millisecond * 1000)
 	wg.Wait()
 	if g, w := str.Get("success"), 70; g != w {
 		t.Errorf("not match success count: got %d want %d", g, w)


### PR DESCRIPTION
FCM v1 endpoint allows multiple payloads in a single request body.